### PR TITLE
Prefer t3 instances

### DIFF
--- a/deployment/cloudformation.yaml
+++ b/deployment/cloudformation.yaml
@@ -121,7 +121,7 @@ Parameters:
   InstanceType:
     Description: EC2 instance type
     Type: String
-    Default: t2.medium
+    Default: t3.medium
     ConstraintDescription: Please choose a valid instance type.
 Outputs:
   PGConnection:
@@ -240,7 +240,7 @@ Resources:
       MasterUsername: !Ref 'DBSuperUser'
       MasterUserPassword: !Ref 'DBSuperPassword'
       AllocatedStorage: '5'
-      DBInstanceClass: db.t2.small
+      DBInstanceClass: db.t3.small
       Engine: Postgres
       EngineVersion: '11'
       PubliclyAccessible: true


### PR DESCRIPTION
AWS t3 instances are the same price (or cheaper) than t2 instances and have better performance.