### PR TITLE
modify search to use inlineable sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ To run tests, the `docker-compose` stack must be running.
 ```bash
 yarn test                   # Run all tests (db, rest)
 yarn test_db                # Run pgTAP tests
-yar test_rest               # Run integration tests
+yarn test_rest               # Run integration tests
 ```
 
 ## Deployment

--- a/db/src/api/satapi.sql
+++ b/db/src/api/satapi.sql
@@ -17,30 +17,31 @@ CREATE OR REPLACE VIEW collectionitems AS
     data.collections c ON i.collection = c.id;
 ALTER VIEW collectionitems owner to api;
 
-CREATE FUNCTION search(
+CREATE OR REPLACE FUNCTION search(
   bbox numeric[] = NULL,
   intersects json = NULL,
-  include TEXT[] = NULL
+  include text[] = NULL
+) RETURNS setof api.collectionitems AS $$
+WITH g AS (
+  SELECT CASE
+  WHEN bbox IS NOT NULL THEN
+      data.ST_MakeEnvelope(
+        bbox[1],
+        bbox[2],
+        bbox[3],
+        bbox[4],
+        4326
+      )
+    WHEN intersects IS NOT NULL THEN
+      data.st_SetSRID(
+        data.ST_GeomFromGeoJSON(intersects),
+        4326
+      )
+    ELSE 
+      NULL
+    END AS geom
 )
-RETURNS setof api.collectionitems
-AS $$
-DECLARE
-  intersects_geometry data.geometry;
-BEGIN
-  IF bbox IS NOT NULL THEN
-    intersects_geometry = data.ST_MakeEnvelope(
-      bbox[1],
-      bbox[2],
-      bbox[3],
-      bbox[4],
-      4326
-    );
-  ELSIF intersects IS NOT NULL THEN
-    intersects_geometry = data.st_SetSRID(data.ST_GeomFromGeoJSON(intersects), 4326);
-  END IF;
-  IF include IS NOT NULL THEN
-    RETURN QUERY
-    SELECT
+SELECT
     collectionproperties,
     collection,
     id,
@@ -49,54 +50,30 @@ BEGIN
     type,
     assets,
     geometry,
-    (select jsonb_object_agg(e.key, e.value)
-      from jsonb_each(properties) e
-      where e.key = ANY (include)) properties,
+    CASE WHEN include IS NULL THEN properties
+    ELSE (
+      SELECT jsonb_object_agg(e.key, e.value)
+      FROM jsonb_each(properties) e
+      WHERE e.key = ANY (include)
+    )
+    END as properties,
     datetime,
     links,
     stac_version
-    FROM api.collectionitems
-    WHERE data.ST_INTERSECTS(collectionitems.geom, intersects_geometry);
-  ELSE
-    RETURN QUERY
-    SELECT *
-    FROM api.collectionitems
-    WHERE data.ST_INTERSECTS(collectionitems.geom, intersects_geometry);
-  END IF;
-END
-$$ LANGUAGE plpgsql IMMUTABLE;
+    FROM api.collectionitems, g
+    WHERE (
+      g.geom IS NULL OR 
+      data.ST_Intersects(g.geom, intersects
+    );
+$$ LANGUAGE SQL IMMUTABLE;
 
 CREATE FUNCTION searchnogeom(
   include TEXT[] = NULL
 )
 RETURNS setof api.collectionitems
 AS $$
-BEGIN
-  IF include IS NOT NULL THEN
-    RETURN QUERY
-    SELECT
-    collectionproperties,
-    collection,
-    id,
-    geom,
-    bbox,
-    type,
-    assets,
-    geometry,
-    (select jsonb_object_agg(e.key, e.value)
-      from jsonb_each(properties) e
-      where e.key = ANY (include)) properties,
-    datetime,
-    links,
-    stac_version
-    FROM api.collectionitems;
-  ELSE
-    RETURN QUERY
-    SELECT *
-    FROM api.collectionitems;
-  END IF;
-END
-$$ LANGUAGE plpgsql IMMUTABLE;
+SELECT * FROM search(NULL, NULL, include);
+$$ LANGUAGE SQL IMMUTABLE;
 
 CREATE OR REPLACE VIEW items AS
   SELECT * FROM data.items_string_geometry;

--- a/db/src/api/satapi.sql
+++ b/db/src/api/satapi.sql
@@ -45,8 +45,8 @@ SELECT
     collectionproperties,
     collection,
     id,
-    geom,
-    collectionitems.bbox,
+    c.geom,
+    c.bbox,
     type,
     assets,
     geometry,
@@ -60,10 +60,10 @@ SELECT
     datetime,
     links,
     stac_version
-    FROM api.collectionitems, g
+    FROM api.collectionitems c, g
     WHERE (
       g.geom IS NULL OR 
-      data.ST_Intersects(g.geom, intersects
+      data.ST_Intersects(g.geom, c.geom)
     );
 $$ LANGUAGE SQL IMMUTABLE;
 

--- a/tests/db/simple.sql
+++ b/tests/db/simple.sql
@@ -1,5 +1,5 @@
 begin;
-select * from no_plan();
+select * from plan(3);
 
 select has_schema('information_schema');
 

--- a/tests/db/structure.sql
+++ b/tests/db/structure.sql
@@ -1,22 +1,15 @@
 begin;
-select * from no_plan();
+select * from plan(2);
 
-select * from check_test(
-    views_are('api',
-    array['collectionitems', 'items', 'collections'],
-    'tables present' ),
-    true,
-    'all views are present in api schema',
-    'tables present',
-    ''
+select views_are(
+    'api',
+    array['collectionitems', 'items', 'collections', 'root'],
+    'views present'
 );
 
-select * from check_test(
-    functions_are('api', array['login', 'signup', 'refresh_token', 'me', 'search', 'searchnogeom'], 'functions present' ),
-    true,
-    'all functions are present in api schema',
-    'functions present',
-    ''
+select functions_are(
+    'api',
+    array['login', 'signup', 'refresh_token', 'me', 'search', 'searchnogeom'], 'functions present'
 );
 
 select * from finish();


### PR DESCRIPTION
Modifies search functions to use straight SQL functions which allow the query planner to inline the sql which should perform quite a bit better than with PLPGSQL.