### PR TITLE
Specify General Purpose SSD for RDS storage

### DIFF
--- a/deployment/cloudformation.yaml
+++ b/deployment/cloudformation.yaml
@@ -240,6 +240,7 @@ Resources:
       MasterUsername: !Ref 'DBSuperUser'
       MasterUserPassword: !Ref 'DBSuperPassword'
       AllocatedStorage: '5'
+      StorageType: 'gp2'
       DBInstanceClass: db.t3.small
       Engine: Postgres
       EngineVersion: '11'


### PR DESCRIPTION
Currently, we don't specify the `StorageType`. According to the [CloudFormation docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-rds-database-instance.html#cfn-rds-dbinstance-storagetype), this should default to a `gp2` storage (aka [General Purpose SSD](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Storage.html#Concepts.Storage)):

> Default: `io1` if the `Iops` parameter is specified, otherwise `gp2`

However, looking at the actual RDS DBs created by with the CF template, I see Magnetic storage. From AWS' Storage docs:

> We recommend that you use General Purpose SSD or Provisioned IOPS for any new storage needs. The maximum amount of storage allowed for DB instances on magnetic storage is less than that of the other storage types.

---

Fun fact: I was looking at storage because my SAT API PG DB ran out of its 5GiB storage, it's at roughly 250k STAC items
