### PR TITLE
Reformat readme into steps

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,39 +1,39 @@
 ## Deploying the sat-api-pg to an AWS stack.
 
 ### Prerequisites
-* [aws-cli](https://aws.amazon.com/cli/)
-* [psql](https://www.postgresql.org/docs/9.5/libpq.html)
 
-Create an [ECR repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-create.html) to house your OpenResty image (the image will be pushed to this repository as part of the `deploy.sh` step below.
+- [aws-cli](https://aws.amazon.com/cli/)
+- [psql](https://www.postgresql.org/docs/9.5/libpq.html)
 
-Copy the `/deployment/.sample_env` to `/deployment/.env`. And update accordingly with the values relevant for your project. 
+### Initial Deployment
 
-Then...
+1. Create an [ECR repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-create.html) to house your OpenResty image. Example name: `sat-api-pg-dev/openresty`
+2. Copy the `./deployment/.sample_env` to `./deployment/.env`. Update accordingly with the values relevant for your project.
+3. Create the stack of required AWS resources:
+   ```bash
+   $ cd deployment
+   $ ./createStack.sh
+   ```
+4. Update the newly created RDS instance's security policy to allow inbound traffic from the IP address of the machine where you are executing the deployment. This will allow the deployment package to run `psql` commands from your IP address.
+5. Build the deployment configuration file from you environment settings. From the `/deployment` directory run:
+   ```bash
+   $ ./createSubZeroConfig.sh
+   ```
+6. Deploy the database migrations and the push the latest OpenResty image to ECR run. This will create the `sat-api-pg` schemas, users, tables, views and functions in your stack's RDS database.
+   ```bash
+   $ ./deploy.sh
+   ```
+7. Now that our database is ready and the updated image is in ECR, bring up an instance of your service:
+   ```bash
+   $ ./createStack.sh 1 # The 1 indicates a single instance of your service
+   ```
 
-To create the stack of required AWS resources. Run
+### Migrations
+
+To create a new Sqitch migration run
+
 ```bash
-$ cd deployment
-$ ./createStack.sh
+$ yarn subzero migrations add --no-diff --note "yournote" yourmigrationname
 ```
 
-Once your AWS stack has been created you can deploy the database creation/migrations and the updated OpenResty image.
-This will create the `sat-api-pg` schemas, users, tables, views and functions in your stack's RDS database.
-Prior to deploying these changes you must update the RDS instance's security policy to allow inbound traffic from the IP address of the machine where you are executing the deployment.
-This will allow the deployment package to run `psql` commands from your IP address.
-
-To build the deployment cofiguration file from you environment settings. From the `/deployment` directory run
-```bash
-$ ./createSubZeroConfig.sh
-```
-
-To deploy the database migrations and the push the latest OpenResty image to ECR run
-```bash
-$ ./deploy.sh
-```
-
-And finally now that our database is ready and the updated image is in ECR you can bring up an instance of your service by running
-```bash
-$ ./createStack.sh 1
-```
-(The 1 indicates a single instance of your service).
-
+This will create the appropriate files in the `migrations` directory which you can then modify with your desired changes.


### PR DESCRIPTION
This reformat is an attempt to put the steps for the initial deployment into succinct numbered list.  This should help developers like myself who have trouble following simple directions 😉.